### PR TITLE
support tmux in an environment with GNU screen

### DIFF
--- a/autoload/fakeclip.vim
+++ b/autoload/fakeclip.vim
@@ -34,7 +34,7 @@ else
 endif
 
 
-if executable('screen')
+if executable('screen') && $STY != ''
   let s:TERMINAL_MULTIPLEXER_TYPE = 'gnuscreen'
 elseif executable('tmux') && $TMUX != ''
   let s:TERMINAL_MULTIPLEXER_TYPE = 'tmux'


### PR DESCRIPTION
fakeclip doesn't work on tmux in an environment where GNU screen is
installed.
