### PR TITLE
Fix pasting from tmux

### DIFF
--- a/autoload/fakeclip.vim
+++ b/autoload/fakeclip.vim
@@ -213,7 +213,7 @@ endfunction
 
 
 function! s:read_pastebuffer_tmux()
-  return system('tmux show-buffer')
+  return system('tmux show-buffer | cat')
 endfunction
 
 


### PR DESCRIPTION
tmux show-buffer behaves weirdly when run from within Vim (ie doesn't simply output buffer to stdout and quit as it does from the shell). I don't know why and don't have time to figure it out, but this is a quick fix which makes it work for me.

I'm using tmux 1.6, vim 7.3.502 and vim-fakeclip 0.2.10
