### PR TITLE
Fix the string comparisons which can be affected by the users ignorecase

### DIFF
--- a/autoload/fakeclip.vim
+++ b/autoload/fakeclip.vim
@@ -124,7 +124,14 @@ function! fakeclip#yank(system_type, motion_type)  "{{{2
   let r0 = s:save_register('0')
 
   call s:select_last_motion(a:motion_type)
-  normal! y
+  if a:motion_type ==# 'V'
+    " Special case: Y in visual mode ignores the start and ending character
+    " of the selection and yanks complete lines spanned by the selection.
+    " See the vnoremap <Plug>(fakeclip-Y) definition in plugin/fakeclip.vim.
+    normal! Y
+  else
+    normal! y
+  endif
   call s:write_{a:system_type}(@@)
 
   call s:restore_register('0', r0)


### PR DESCRIPTION
This includes changes to comparisons which are insensitive to the ignorecase setting but it's important to be consistent to avoid ambiguity. Note: The only broken comparison actually fixed is on line 86. This resolves issue #11 that I opened when I noticed the problem.

This also fixes issue #3 where "Y" in visual mode doesn't yank complete lines.
