### PR TITLE
Add lemonade support

### DIFF
--- a/autoload/fakeclip.vim
+++ b/autoload/fakeclip.vim
@@ -31,6 +31,8 @@ elseif has('win32unix')
   let s:PLATFORM = 'cygwin'
 elseif $DISPLAY != '' && executable('xclip')
   let s:PLATFORM = 'x'
+elseif executable('lemonade')
+  let s:PLATFORM = 'lemonade'
 else
   let s:PLATFORM = 'unknown'
 endif
@@ -185,6 +187,11 @@ function! s:read_clipboard_x()
 endfunction
 
 
+function! s:read_clipboard_lemonade()
+  return system('lemonade paste')
+endfunction
+
+
 function! s:read_clipboard_unknown()
   echoerr 'Getting the clipboard content is not supported on this platform:'
   \       s:PLATFORM
@@ -261,6 +268,12 @@ endfunction
 
 function! s:write_clipboard_x(text)
   call system('xclip', a:text)
+  return
+endfunction
+
+
+function! s:write_clipboard_lemonade(text)
+  call system('lemonade copy', a:text)
   return
 endfunction
 

--- a/doc/fakeclip.txt
+++ b/doc/fakeclip.txt
@@ -47,6 +47,7 @@ version of Vim on the following platforms:
 - Cygwin
 - Mac OS X
 - X Window System (by xclip <http://sourceforge.net/projects/xclip/>)
+- lemonade (<https://github.com/pocke/lemonade>)
 
 
 fakeclip also provides a pseudo register to access a "paste buffer" if one of

--- a/t/clipboard-io.vim
+++ b/t/clipboard-io.vim
@@ -36,4 +36,13 @@ describe 'fakeclip'
       Expect Call('s:read_clipboard_x') ==# "Foo\nBar\nBaz"
     end
   end
+
+  context 'on lemonade'
+    it 'can read/write the clipboard'
+      ExpectedPlatform lemonade
+
+      call Call('s:write_clipboard_lemonade', "Foo\nBar\nBaz")
+      Expect Call('s:read_clipboard_lemonade') ==# "Foo\nBar\nBaz"
+    end
+  end
 end


### PR DESCRIPTION
I added [lemonade](https://github.com/pocke/lemonade) support.
Lemonade can transport the content of clipboard between remote and localhost.  This is very useful. I want to use this from Vim.

However, lemonade is not a platform... hmm...

Or... should we make it more customizable like #14?

---

BTW, I tried to run tests, but they failed.

```
$ bundle install
$ rake test
...(snip)...
not ok 1 - fakeclip on Mac can read/write the clipboard
# SyntaxError: Invalid string - '''not on the platform'' | end'
...(snip)...
```

Problem lines: https://github.com/kana/vim-fakeclip/blob/b02d8a9140d800f4a07af82fa31b6189bb3b66c6/t/clipboard-io.vim#L8-L10

[`:SKIP` command in vspec 1.6.1](https://github.com/kana/vim-vspec/blob/6e56426dff63b0ed16f2120924bb49b30075f91e/autoload/vspec.vim#L131) does not have `-bar` flag(dropped in [this commit](https://github.com/kana/vim-vspec/commit/5ff3db17941818aab36afab69cf884f264e4f9db)).
