### PR TITLE
A series of my ideas

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,6 @@
+vim-fakeclip
+============
+
+Vim plugin: Provide pseudo "clipboard" registers
+
+This is a straight fork or the main repo with the outstanding pull requests merged in -- because I wanted them. 

--- a/autoload/fakeclip.vim
+++ b/autoload/fakeclip.vim
@@ -60,6 +60,13 @@ endif
 
 
 " Interface  "{{{1
+function! fakeclip#should_distinguish_primary_and_clipboard()  "{{{2
+    return s:PLATFORM == 'x'
+endfunction
+
+
+
+
 function! fakeclip#clipboard_delete(motion_type)  "{{{2
   return fakeclip#delete('clipboard', a:motion_type)
 endfunction
@@ -70,6 +77,22 @@ endfunction
 function! fakeclip#clipboard_yank(motion_type)  "{{{2
   return fakeclip#yank('clipboard', a:motion_type)
 endfunction
+
+
+
+
+if fakeclip#should_distinguish_primary_and_clipboard()
+function! fakeclip#primary_delete(motion_type)  "{{{2
+  return fakeclip#delete('primary', a:motion_type)
+endfunction
+
+
+
+
+function! fakeclip#primary_yank(motion_type)  "{{{2
+  return fakeclip#yank('primary', a:motion_type)
+endfunction
+endif
 
 
 
@@ -139,9 +162,14 @@ function! fakeclip#yank_Y(system_type)  "{{{2
   if 0 < diff
     execute 'normal!' diff.'j'
   endif
-  execute 'normal' (a:system_type ==# 'clipboard'
-  \                 ? "\<Plug>(fakeclip-Y)"
-  \                 : "\<Plug>(fakeclip-screen-Y)")
+  if a:system_type ==# 'clipboard'
+    let t = ''
+  elseif a:system_type ==# 'primary'
+    let t = '-primary'
+  else
+    let t = '-screen'
+  endif
+  execute 'normal' "\<Plug>(fakeclip".t.'-Y)'
 endfunction
 
 
@@ -172,7 +200,7 @@ endfunction
 
 
 function! s:read_clipboard_x()
-  return system('xclip -o')
+  return system('xclip -o -selection clipboard')
 endfunction
 
 
@@ -181,6 +209,19 @@ function! s:read_clipboard_unknown()
   \       s:PLATFORM
   return ''
 endfunction
+
+
+
+if fakeclip#should_distinguish_primary_and_clipboard()
+function! s:read_primary()  "{{{2
+  return s:read_primary_{s:PLATFORM}()
+endfunction
+
+
+function! s:read_primary_x()
+  return system('xclip -o -selection primary')
+endfunction
+endif
 
 
 
@@ -248,7 +289,7 @@ endfunction
 
 
 function! s:write_clipboard_x(text)
-  call system('xclip', a:text)
+  call system('xclip -selection clipboard', a:text)
   return
 endfunction
 
@@ -258,6 +299,26 @@ function! s:write_clipboard_unknown(text)
   \       s:PLATFORM
   return
 endfunction
+
+
+
+
+if fakeclip#should_distinguish_primary_and_clipboard()
+function! s:write_primary(text)  "{{{2
+  if exists('g:fakeclip_write_primary_command')
+    call system(g:fakeclip_write_primary_command, a:text)
+  else
+    call s:write_primary_{s:PLATFORM}(a:text)
+  endif
+  return
+endfunction
+
+
+function! s:write_primary_x(text)
+  call system('xclip -selection primary', a:text)
+  return
+endfunction
+endif
 
 
 

--- a/autoload/fakeclip.vim
+++ b/autoload/fakeclip.vim
@@ -196,7 +196,11 @@ endfunction
 
 " Core  "{{{1
 function! s:read_clipboard()  "{{{2
-  return s:read_clipboard_{s:PLATFORM}()
+  if exists('g:fakeclip_read_clipboard_command')
+    return system(g:fakeclip_read_clipboard_command)
+  else
+    return s:read_clipboard_{s:PLATFORM}()
+  endif
 endfunction
 
 
@@ -229,7 +233,11 @@ endfunction
 
 if fakeclip#should_distinguish_primary_and_clipboard()
 function! s:read_primary()  "{{{2
-  return s:read_primary_{s:PLATFORM}()
+  if exists('g:fakeclip_read_primary_command')
+    return system(g:fakeclip_read_primary_command)
+  else
+    return s:read_primary_{s:PLATFORM}()
+  endif
 endfunction
 
 

--- a/autoload/fakeclip.vim
+++ b/autoload/fakeclip.vim
@@ -21,8 +21,23 @@
 "     TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 "     SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 " }}}
-" Platform detection  "{{{1
+" Load once   "{{{1
+if exists("g:loaded_fakeclip_autoload")
+  finish
+endif
+let g:loaded_fakeclip_autoload = 1
 
+let s:save_cpo = &cpo
+set cpo&vim
+
+
+
+
+
+
+
+
+" Platform detection  "{{{1
 if has('macunix') || system('uname') =~? '^darwin'
   let s:PLATFORM = 'mac'
 elseif has('win32unix')
@@ -422,4 +437,7 @@ endfunction
 
 
 " __END__  "{{{1
+let &cpo = s:save_cpo
+
+
 " vim: foldmethod=marker

--- a/doc/fakeclip.txt
+++ b/doc/fakeclip.txt
@@ -194,7 +194,7 @@ this plugin is loaded (e.g. in your |vimrc|).  You can also use
 |:FakeclipDefaultKeyMappings| to redefine these key mappings.  This command
 doesn't override existing {lhs}s unless [!] is given.
 
-					*fakeclip_x11_primary_selection_notes*
+					*fakeclip-x11-primary-selection-notes*
 NOTE:  On X11 systems, there are actually three distinct "clipboards", or
 X selections, namely the PRIMARY, SECONDARY and CLIPBOARD selections.  To
 emulate Vim's behaviour under X11 (see |quote+|), this plugin uses the "+"

--- a/doc/fakeclip.txt
+++ b/doc/fakeclip.txt
@@ -113,6 +113,43 @@ KEY MAPPINGS					*fakeclip-key-mappings*
 			clipboard.
 	
 
+[count]<Plug>(fakeclip-primary-y){motion}	*<Plug>(fakeclip-primary-y)*
+[count]<Plug>(fakeclip-primary-Y)		*<Plug>(fakeclip-primary-Y)*
+{Visual}<Plug>(fakeclip-primary-y)		*v_<Plug>(fakeclip-primary-y)*
+{Visual}<Plug>(fakeclip-primary-Y)		*v_<Plug>(fakeclip-primary-Y)*
+			Like |y| or |Y|, but yank into the X primary selection.
+
+[count]<Plug>(fakeclip-primary-d){motion}	*<Plug>(fakeclip-primary-d)*
+[count]<Plug>(fakeclip-primary-dd)		*<Plug>(fakeclip-primary-dd)*
+[count]<Plug>(fakeclip-primary-D)		*<Plug>(fakeclip-primary-D)*
+{Visual}<Plug>(fakeclip-primary-d)		*v_<Plug>(fakeclip-primary-d)*
+{Visual}<Plug>(fakeclip-primary-D)		*v_<Plug>(fakeclip-primary-D)*
+			Like |d|, |dd| or |D|, but cut into the X primary
+			selection.
+
+[count]<Plug>(fakeclip-primary-p)		*<Plug>(fakeclip-primary-p)*
+[count]<Plug>(fakeclip-primary-P)		*<Plug>(fakeclip-primary-P)*
+[count]<Plug>(fakeclip-primary-gp)		*<Plug>(fakeclip-primary-gp)*
+[count]<Plug>(fakeclip-primary-gP)		*<Plug>(fakeclip-primary-gP)*
+[count]<Plug>(fakeclip-primary-]p)		*<Plug>(fakeclip-primary-]p)*
+[count]<Plug>(fakeclip-primary-]P)		*<Plug>(fakeclip-primary-]P)*
+[count]<Plug>(fakeclip-primary-[p)		*<Plug>(fakeclip-primary-[p)*
+[count]<Plug>(fakeclip-primary-[P)		*<Plug>(fakeclip-primary-[P)*
+			Like |p|, |P|, |gp|, |gP|, |]p|, |]P|, |[p| or
+			|[P|, but put from the X primary selection.
+					*c_<Plug>(fakeclip-primary-insert)*
+<Plug>(fakeclip-primary-insert)		*i_<Plug>(fakeclip-primary-insert)*
+					*c_<Plug>(fakeclip-primary-insert-r)*
+<Plug>(fakeclip-primary-insert-r)	*i_<Plug>(fakeclip-primary-insert-r)*
+					*c_<Plug>(fakeclip-primary-insert-o)*
+<Plug>(fakeclip-primary-insert-o)	*i_<Plug>(fakeclip-primary-insert-o)*
+<Plug>(fakeclip-primary-insert-p)	*i_<Plug>(fakeclip-primary-insert-p)*
+			Like |i_CTRL-R|, |i_CTRL-R_CTRL-R|, |i_CTRL-R_CTRL-O|,
+			|i_CTRL-R_CTRL-P|, |c_CTRL-R|, |c_CTRL-R_CTRL-R| or
+			|c_CTRL-R_CTRL-O|, but insert the content of the
+			X primary selection.
+
+
 [count]<Plug>(fakeclip-screen-y){motion}	*<Plug>(fakeclip-screen-y)*
 [count]<Plug>(fakeclip-screen-Y)		*<Plug>(fakeclip-screen-Y)*
 {Visual}<Plug>(fakeclip-screen-y)		*v_<Plug>(fakeclip-screen-y)*
@@ -157,44 +194,56 @@ this plugin is loaded (e.g. in your |vimrc|).  You can also use
 |:FakeclipDefaultKeyMappings| to redefine these key mappings.  This command
 doesn't override existing {lhs}s unless [!] is given.
 
+					*fakeclip_x11_primary_selection_notes*
+NOTE:  On X11 systems, there are actually three distinct "clipboards", or
+X selections, namely the PRIMARY, SECONDARY and CLIPBOARD selections.  To
+emulate Vim's behaviour under X11 (see |quote+|), this plugin uses the "+"
+register for accessing the CLIPBOARD selection, and the "*" register for the
+PRIMARY selection.  On non-X11 systems, the distinction is probably moot.
+Therefore, the fakeclip-primary-* {rhs}s will not be defined, and both the
+"+" and the "*" registers will access the same clipboard.
+
 	modes	{lhs}		{rhs}					~
 	-----	-----------	--------------------------------	~
 	nv	"+y		<Plug>(fakeclip-y)
-	nv	"*y		<Plug>(fakeclip-y)
+	nv	"*y		<Plug>(fakeclip-primary-y)	(X11 only)
 	n	"+yy		<Plug>(fakeclip-Y)
-	n	"*yy		<Plug>(fakeclip-Y)
+	n	"*yy		<Plug>(fakeclip-primary-Y)	(X11 only)
 	nv	"+Y		<Plug>(fakeclip-Y)
-	nv	"*Y		<Plug>(fakeclip-Y)
+	nv	"*Y		<Plug>(fakeclip-primary-Y)	(X11 only)
 	nv	"+d		<Plug>(fakeclip-d)
-	nv	"*d		<Plug>(fakeclip-d)
+	nv	"*d		<Plug>(fakeclip-primary-d)	(X11 only)
 	n	"+dd		<Plug>(fakeclip-dd)
-	n	"*dd		<Plug>(fakeclip-dd)
+	n	"*dd		<Plug>(fakeclip-primary-dd)	(X11 only)
 	nv	"+D		<Plug>(fakeclip-D)
-	nv	"*D		<Plug>(fakeclip-D)
+	nv	"*D		<Plug>(fakeclip-primary-D)	(X11 only)
 	nv	"+p		<Plug>(fakeclip-p)
-	nv	"*p		<Plug>(fakeclip-p)
+	nv	"*p		<Plug>(fakeclip-primary-p)	(X11 only)
 	nv	"+P		<Plug>(fakeclip-P)
-	nv	"*P		<Plug>(fakeclip-P)
+	nv	"*P		<Plug>(fakeclip-primary-P)	(X11 only)
 	nv	"+gp		<Plug>(fakeclip-gp)
-	nv	"*gp		<Plug>(fakeclip-gp)
+	nv	"*gp		<Plug>(fakeclip-primary-gp)	(X11 only)
 	nv	"+gP		<Plug>(fakeclip-gP)
-	nv	"*gP		<Plug>(fakeclip-gP)
+	nv	"*gP		<Plug>(fakeclip-primary-gP)	(X11 only)
 	nv	"+]p		<Plug>(fakeclip-]p)
-	nv	"*]p		<Plug>(fakeclip-]p)
+	nv	"*]p		<Plug>(fakeclip-primary-]p)	(X11 only)
 	nv	"+]P		<Plug>(fakeclip-]P)
-	nv	"*]P		<Plug>(fakeclip-]P)
+	nv	"*]P		<Plug>(fakeclip-primary-]P)	(X11 only)
 	nv	"+[p		<Plug>(fakeclip-[p)
-	nv	"*[p		<Plug>(fakeclip-[p)
+	nv	"*[p		<Plug>(fakeclip-primary-[p)	(X11 only)
 	nv	"+[P		<Plug>(fakeclip-[P)
-	nv	"*[P		<Plug>(fakeclip-[P)
+	nv	"*[P		<Plug>(fakeclip-primary-[P)	(X11 only)
 	ic	<C-r>+		<Plug>(fakeclip-insert)
-	ic	<C-r>*		<Plug>(fakeclip-insert)
+	ic	<C-r>*		<Plug>(fakeclip-primary-insert)	(X11 only)
 	ic	<C-r><C-r>+	<Plug>(fakeclip-insert-r)
-	ic	<C-r><C-r>*	<Plug>(fakeclip-insert-r)
+	ic	<C-r><C-r>*	<Plug>(fakeclip-primary-insert-r)
+								(X11 only)
 	ic	<C-r><C-o>+	<Plug>(fakeclip-insert-o)
-	ic	<C-r><C-o>*	<Plug>(fakeclip-insert-o)
+	ic	<C-r><C-o>*	<Plug>(fakeclip-primary-insert-o)
+								(X11 only)
 	i	<C-r><C-p>+	<Plug>(fakeclip-insert-p)
-	i	<C-r><C-p>*	<Plug>(fakeclip-insert-p)
+	i	<C-r><C-p>*	<Plug>(fakeclip-primary-insert-p)
+								(X11 only)
 	nv	"&y		<Plug>(fakeclip-screen-y)
 	n	"&yy		<Plug>(fakeclip-screen-Y)
 	nv	"&Y		<Plug>(fakeclip-screen-Y)

--- a/plugin/fakeclip.vim
+++ b/plugin/fakeclip.vim
@@ -100,6 +100,73 @@ vnoremap <silent> <Plug>(fakeclip-D)
 \ :<C-u>call fakeclip#delete('clipboard', 'V')<Return>
 
 
+" begin XXX
+if fakeclip#should_distinguish_primary_and_clipboard()
+nnoremap <silent> <Plug>(fakeclip-primary-y)
+\ :<C-u>set operatorfunc=fakeclip#primary_yank<Return>g@
+vnoremap <silent> <Plug>(fakeclip-primary-y)
+\ :<C-u>call fakeclip#yank('primary', visualmode())<Return>
+nnoremap <silent> <Plug>(fakeclip-primary-Y)
+\ :<C-u>call fakeclip#yank_Y('primary')<Return>
+vnoremap <silent> <Plug>(fakeclip-primary-Y)
+\ :<C-u>call fakeclip#yank('primary', 'V')<Return>
+
+nnoremap <silent> <Plug>(fakeclip-primary-p)
+\ :<C-u>call fakeclip#put('primary', '', 'p')<Return>
+nnoremap <silent> <Plug>(fakeclip-primary-P)
+\ :<C-u>call fakeclip#put('primary', '', 'P')<Return>
+nnoremap <silent> <Plug>(fakeclip-primary-gp)
+\ :<C-u>call fakeclip#put('primary', '', 'gp')<Return>
+nnoremap <silent> <Plug>(fakeclip-primary-gP)
+\ :<C-u>call fakeclip#put('primary', '', 'gP')<Return>
+nnoremap <silent> <Plug>(fakeclip-primary-]p)
+\ :<C-u>call fakeclip#put('primary', '', ']p')<Return>
+nnoremap <silent> <Plug>(fakeclip-primary-]P)
+\ :<C-u>call fakeclip#put('primary', '', ']P')<Return>
+nnoremap <silent> <Plug>(fakeclip-primary-[p)
+\ :<C-u>call fakeclip#put('primary', '', '[p')<Return>
+nnoremap <silent> <Plug>(fakeclip-primary-[P)
+\ :<C-u>call fakeclip#put('primary', '', '[P')<Return>
+vnoremap <silent> <Plug>(fakeclip-primary-p)
+\ :<C-u>call fakeclip#put('primary', visualmode(), 'p')<Return>
+vnoremap <silent> <Plug>(fakeclip-primary-P)
+\ :<C-u>call fakeclip#put('primary', visualmode(), 'P')<Return>
+vnoremap <silent> <Plug>(fakeclip-primary-gp)
+\ :<C-u>call fakeclip#put('primary', visualmode(), 'gp')<Return>
+vnoremap <silent> <Plug>(fakeclip-primary-gP)
+\ :<C-u>call fakeclip#put('primary', visualmode(), 'gP')<Return>
+vnoremap <silent> <Plug>(fakeclip-primary-]p)
+\ :<C-u>call fakeclip#put('primary', visualmode(), ']p')<Return>
+vnoremap <silent> <Plug>(fakeclip-primary-]P)
+\ :<C-u>call fakeclip#put('primary', visualmode(), ']P')<Return>
+vnoremap <silent> <Plug>(fakeclip-primary-[p)
+\ :<C-u>call fakeclip#put('primary', visualmode(), '[p')<Return>
+vnoremap <silent> <Plug>(fakeclip-primary-[P)
+\ :<C-u>call fakeclip#put('primary', visualmode(), '[P')<Return>
+
+noremap! <Plug>(fakeclip-primary-insert)
+\ <C-r>=fakeclip#content('primary')<Return>
+noremap! <Plug>(fakeclip-primary-insert-r)
+\ <C-r><C-r>=fakeclip#content('primary')<Return>
+noremap! <Plug>(fakeclip-primary-insert-o)
+\ <C-r><C-o>=fakeclip#content('primary')<Return>
+inoremap <Plug>(fakeclip-primary-insert-p)
+\ <C-r><C-p>=fakeclip#content('primary')<Return>
+
+nnoremap <silent> <Plug>(fakeclip-primary-d)
+\ :<C-u>set operatorfunc=fakeclip#primary_delete<Return>g@
+vnoremap <silent> <Plug>(fakeclip-primary-d)
+\ :<C-u>call fakeclip#delete('primary', visualmode())<Return>
+nnoremap <silent> <Plug>(fakeclip-primary-dd)
+\ :<C-u>set operatorfunc=fakeclip#primary_delete<Return>g@g@
+nnoremap <silent> <Plug>(fakeclip-primary-D)
+\ :<C-u>set operatorfunc=fakeclip#primary_delete<Return>g@$
+vnoremap <silent> <Plug>(fakeclip-primary-D)
+\ :<C-u>call fakeclip#delete('primary', 'V')<Return>
+endif
+" end XXX
+
+
 nnoremap <silent> <Plug>(fakeclip-screen-y)
 \ :<C-u>set operatorfunc=fakeclip#pastebuffer_yank<Return>g@
 vnoremap <silent> <Plug>(fakeclip-screen-y)
@@ -174,40 +241,45 @@ function! s:cmd_FakeclipDefaultKeyMappings(banged_p)
   let modifier = a:banged_p ? '' : '<unique>'
   " Clipboard
   if !has('clipboard') || get(g:, 'fakeclip_provide_clipboard_key_mappings', 0)
-    for _ in ['+', '*']
-      execute 'silent! nmap '.modifier.' "'._.'y  <Plug>(fakeclip-y)'
-      execute 'silent! nmap '.modifier.' "'._.'Y  <Plug>(fakeclip-Y)'
-      execute 'silent! nmap '.modifier.' "'._.'yy  <Plug>(fakeclip-Y)'
-      execute 'silent! vmap '.modifier.' "'._.'y  <Plug>(fakeclip-y)'
-      execute 'silent! vmap '.modifier.' "'._.'Y  <Plug>(fakeclip-Y)'
+    let register_keys = ['*', '+']
+    let l:t = {'*': '', '+': ''}
+    if fakeclip#should_distinguish_primary_and_clipboard()
+	let l:t['*'] = '-primary'
+    endif
+    for _ in register_keys
+      execute 'silent! nmap '.modifier.' "'._.'y  <Plug>(fakeclip'.l:t[_].'-y)'
+      execute 'silent! nmap '.modifier.' "'._.'Y  <Plug>(fakeclip'.l:t[_].'-Y)'
+      execute 'silent! nmap '.modifier.' "'._.'yy  <Plug>(fakeclip'.l:t[_].'-Y)'
+      execute 'silent! vmap '.modifier.' "'._.'y  <Plug>(fakeclip'.l:t[_].'-y)'
+      execute 'silent! vmap '.modifier.' "'._.'Y  <Plug>(fakeclip'.l:t[_].'-Y)'
 
-      execute 'silent! nmap '.modifier.' "'._.'p  <Plug>(fakeclip-p)'
-      execute 'silent! nmap '.modifier.' "'._.'P  <Plug>(fakeclip-P)'
-      execute 'silent! nmap '.modifier.' "'._.'gp  <Plug>(fakeclip-gp)'
-      execute 'silent! nmap '.modifier.' "'._.'gP  <Plug>(fakeclip-gP)'
-      execute 'silent! nmap '.modifier.' "'._.']p  <Plug>(fakeclip-]p)'
-      execute 'silent! nmap '.modifier.' "'._.']P  <Plug>(fakeclip-]P)'
-      execute 'silent! nmap '.modifier.' "'._.'[p  <Plug>(fakeclip-[p)'
-      execute 'silent! nmap '.modifier.' "'._.'[P  <Plug>(fakeclip-[P)'
-      execute 'silent! vmap '.modifier.' "'._.'p  <Plug>(fakeclip-p)'
-      execute 'silent! vmap '.modifier.' "'._.'P  <Plug>(fakeclip-P)'
-      execute 'silent! vmap '.modifier.' "'._.'gp  <Plug>(fakeclip-gp)'
-      execute 'silent! vmap '.modifier.' "'._.'gP  <Plug>(fakeclip-gP)'
-      execute 'silent! vmap '.modifier.' "'._.']p  <Plug>(fakeclip-]p)'
-      execute 'silent! vmap '.modifier.' "'._.']P  <Plug>(fakeclip-]P)'
-      execute 'silent! vmap '.modifier.' "'._.'[p  <Plug>(fakeclip-[p)'
-      execute 'silent! vmap '.modifier.' "'._.'[P  <Plug>(fakeclip-[P)'
+      execute 'silent! nmap '.modifier.' "'._.'p  <Plug>(fakeclip'.l:t[_].'-p)'
+      execute 'silent! nmap '.modifier.' "'._.'P  <Plug>(fakeclip'.l:t[_].'-P)'
+      execute 'silent! nmap '.modifier.' "'._.'gp  <Plug>(fakeclip'.l:t[_].'-gp)'
+      execute 'silent! nmap '.modifier.' "'._.'gP  <Plug>(fakeclip'.l:t[_].'-gP)'
+      execute 'silent! nmap '.modifier.' "'._.']p  <Plug>(fakeclip'.l:t[_].'-]p)'
+      execute 'silent! nmap '.modifier.' "'._.']P  <Plug>(fakeclip'.l:t[_].'-]P)'
+      execute 'silent! nmap '.modifier.' "'._.'[p  <Plug>(fakeclip'.l:t[_].'-[p)'
+      execute 'silent! nmap '.modifier.' "'._.'[P  <Plug>(fakeclip'.l:t[_].'-[P)'
+      execute 'silent! vmap '.modifier.' "'._.'p  <Plug>(fakeclip'.l:t[_].'-p)'
+      execute 'silent! vmap '.modifier.' "'._.'P  <Plug>(fakeclip'.l:t[_].'-P)'
+      execute 'silent! vmap '.modifier.' "'._.'gp  <Plug>(fakeclip'.l:t[_].'-gp)'
+      execute 'silent! vmap '.modifier.' "'._.'gP  <Plug>(fakeclip'.l:t[_].'-gP)'
+      execute 'silent! vmap '.modifier.' "'._.']p  <Plug>(fakeclip'.l:t[_].'-]p)'
+      execute 'silent! vmap '.modifier.' "'._.']P  <Plug>(fakeclip'.l:t[_].'-]P)'
+      execute 'silent! vmap '.modifier.' "'._.'[p  <Plug>(fakeclip'.l:t[_].'-[p)'
+      execute 'silent! vmap '.modifier.' "'._.'[P  <Plug>(fakeclip'.l:t[_].'-[P)'
 
-      execute 'silent! map! '.modifier.' <C-r>'._.'  <Plug>(fakeclip-insert)'
-      execute 'silent! map! '.modifier.' <C-r><C-r>'._.'  <Plug>(fakeclip-insert-r)'
-      execute 'silent! map! '.modifier.' <C-r><C-o>'._.'  <Plug>(fakeclip-insert-o)'
-      execute 'silent! imap '.modifier.' <C-r><C-p>'._.'  <Plug>(fakeclip-insert-p)'
+      execute 'silent! map! '.modifier.' <C-r>'._.'  <Plug>(fakeclip'.l:t[_].'-insert)'
+      execute 'silent! map! '.modifier.' <C-r><C-r>'._.'  <Plug>(fakeclip'.l:t[_].'-insert-r)'
+      execute 'silent! map! '.modifier.' <C-r><C-o>'._.'  <Plug>(fakeclip'.l:t[_].'-insert-o)'
+      execute 'silent! imap '.modifier.' <C-r><C-p>'._.'  <Plug>(fakeclip'.l:t[_].'-insert-p)'
 
-      execute 'silent! nmap '.modifier.' "'._.'d  <Plug>(fakeclip-d)'
-      execute 'silent! vmap '.modifier.' "'._.'d  <Plug>(fakeclip-d)'
-      execute 'silent! nmap '.modifier.' "'._.'dd  <Plug>(fakeclip-dd)'
-      execute 'silent! nmap '.modifier.' "'._.'D  <Plug>(fakeclip-D)'
-      execute 'silent! vmap '.modifier.' "'._.'D  <Plug>(fakeclip-D)'
+      execute 'silent! nmap '.modifier.' "'._.'d  <Plug>(fakeclip'.l:t[_].'-d)'
+      execute 'silent! vmap '.modifier.' "'._.'d  <Plug>(fakeclip'.l:t[_].'-d)'
+      execute 'silent! nmap '.modifier.' "'._.'dd  <Plug>(fakeclip'.l:t[_].'-dd)'
+      execute 'silent! nmap '.modifier.' "'._.'D  <Plug>(fakeclip'.l:t[_].'-D)'
+      execute 'silent! vmap '.modifier.' "'._.'D  <Plug>(fakeclip'.l:t[_].'-D)'
     endfor
   endif
 

--- a/plugin/fakeclip.vim
+++ b/plugin/fakeclip.vim
@@ -239,84 +239,51 @@ command! -bang -bar -nargs=0 FakeclipDefaultKeyMappings
 
 function! s:cmd_FakeclipDefaultKeyMappings(banged_p)
   let modifier = a:banged_p ? '' : '<unique>'
+  " Paste buffer
+  let l:t = {'&': '-screen'}
   " Clipboard
   if !has('clipboard') || get(g:, 'fakeclip_provide_clipboard_key_mappings', 0)
-    let register_keys = ['*', '+']
-    let l:t = {'*': '', '+': ''}
+    let l:t['*'] = ''
+    let l:t['+'] = ''
     if fakeclip#should_distinguish_primary_and_clipboard()
 	let l:t['*'] = '-primary'
     endif
-    for _ in register_keys
-      execute 'silent! nmap '.modifier.' "'._.'y  <Plug>(fakeclip'.l:t[_].'-y)'
-      execute 'silent! nmap '.modifier.' "'._.'Y  <Plug>(fakeclip'.l:t[_].'-Y)'
-      execute 'silent! nmap '.modifier.' "'._.'yy  <Plug>(fakeclip'.l:t[_].'-Y)'
-      execute 'silent! vmap '.modifier.' "'._.'y  <Plug>(fakeclip'.l:t[_].'-y)'
-      execute 'silent! vmap '.modifier.' "'._.'Y  <Plug>(fakeclip'.l:t[_].'-Y)'
-
-      execute 'silent! nmap '.modifier.' "'._.'p  <Plug>(fakeclip'.l:t[_].'-p)'
-      execute 'silent! nmap '.modifier.' "'._.'P  <Plug>(fakeclip'.l:t[_].'-P)'
-      execute 'silent! nmap '.modifier.' "'._.'gp  <Plug>(fakeclip'.l:t[_].'-gp)'
-      execute 'silent! nmap '.modifier.' "'._.'gP  <Plug>(fakeclip'.l:t[_].'-gP)'
-      execute 'silent! nmap '.modifier.' "'._.']p  <Plug>(fakeclip'.l:t[_].'-]p)'
-      execute 'silent! nmap '.modifier.' "'._.']P  <Plug>(fakeclip'.l:t[_].'-]P)'
-      execute 'silent! nmap '.modifier.' "'._.'[p  <Plug>(fakeclip'.l:t[_].'-[p)'
-      execute 'silent! nmap '.modifier.' "'._.'[P  <Plug>(fakeclip'.l:t[_].'-[P)'
-      execute 'silent! vmap '.modifier.' "'._.'p  <Plug>(fakeclip'.l:t[_].'-p)'
-      execute 'silent! vmap '.modifier.' "'._.'P  <Plug>(fakeclip'.l:t[_].'-P)'
-      execute 'silent! vmap '.modifier.' "'._.'gp  <Plug>(fakeclip'.l:t[_].'-gp)'
-      execute 'silent! vmap '.modifier.' "'._.'gP  <Plug>(fakeclip'.l:t[_].'-gP)'
-      execute 'silent! vmap '.modifier.' "'._.']p  <Plug>(fakeclip'.l:t[_].'-]p)'
-      execute 'silent! vmap '.modifier.' "'._.']P  <Plug>(fakeclip'.l:t[_].'-]P)'
-      execute 'silent! vmap '.modifier.' "'._.'[p  <Plug>(fakeclip'.l:t[_].'-[p)'
-      execute 'silent! vmap '.modifier.' "'._.'[P  <Plug>(fakeclip'.l:t[_].'-[P)'
-
-      execute 'silent! map! '.modifier.' <C-r>'._.'  <Plug>(fakeclip'.l:t[_].'-insert)'
-      execute 'silent! map! '.modifier.' <C-r><C-r>'._.'  <Plug>(fakeclip'.l:t[_].'-insert-r)'
-      execute 'silent! map! '.modifier.' <C-r><C-o>'._.'  <Plug>(fakeclip'.l:t[_].'-insert-o)'
-      execute 'silent! imap '.modifier.' <C-r><C-p>'._.'  <Plug>(fakeclip'.l:t[_].'-insert-p)'
-
-      execute 'silent! nmap '.modifier.' "'._.'d  <Plug>(fakeclip'.l:t[_].'-d)'
-      execute 'silent! vmap '.modifier.' "'._.'d  <Plug>(fakeclip'.l:t[_].'-d)'
-      execute 'silent! nmap '.modifier.' "'._.'dd  <Plug>(fakeclip'.l:t[_].'-dd)'
-      execute 'silent! nmap '.modifier.' "'._.'D  <Plug>(fakeclip'.l:t[_].'-D)'
-      execute 'silent! vmap '.modifier.' "'._.'D  <Plug>(fakeclip'.l:t[_].'-D)'
-    endfor
   endif
+  for [l:k, l:v] in items(l:t)
+    execute 'silent! nmap '.modifier.' "'.l:k.'y  <Plug>(fakeclip'.l:v.'-y)'
+    execute 'silent! nmap '.modifier.' "'.l:k.'Y  <Plug>(fakeclip'.l:v.'-Y)'
+    execute 'silent! nmap '.modifier.' "'.l:k.'yy  <Plug>(fakeclip'.l:v.'-Y)'
+    execute 'silent! vmap '.modifier.' "'.l:k.'y  <Plug>(fakeclip'.l:v.'-y)'
+    execute 'silent! vmap '.modifier.' "'.l:k.'Y  <Plug>(fakeclip'.l:v.'-Y)'
 
-  " Paste buffer
-  execute 'silent! nmap '.modifier.' "&y  <Plug>(fakeclip-screen-y)'
-  execute 'silent! nmap '.modifier.' "&Y  <Plug>(fakeclip-screen-Y)'
-  execute 'silent! nmap '.modifier.' "&yy  <Plug>(fakeclip-screen-Y)'
-  execute 'silent! vmap '.modifier.' "&y  <Plug>(fakeclip-screen-y)'
-  execute 'silent! vmap '.modifier.' "&Y  <Plug>(fakeclip-screen-Y)'
+    execute 'silent! nmap '.modifier.' "'.l:k.'p  <Plug>(fakeclip'.l:v.'-p)'
+    execute 'silent! nmap '.modifier.' "'.l:k.'P  <Plug>(fakeclip'.l:v.'-P)'
+    execute 'silent! nmap '.modifier.' "'.l:k.'gp  <Plug>(fakeclip'.l:v.'-gp)'
+    execute 'silent! nmap '.modifier.' "'.l:k.'gP  <Plug>(fakeclip'.l:v.'-gP)'
+    execute 'silent! nmap '.modifier.' "'.l:k.']p  <Plug>(fakeclip'.l:v.'-]p)'
+    execute 'silent! nmap '.modifier.' "'.l:k.']P  <Plug>(fakeclip'.l:v.'-]P)'
+    execute 'silent! nmap '.modifier.' "'.l:k.'[p  <Plug>(fakeclip'.l:v.'-[p)'
+    execute 'silent! nmap '.modifier.' "'.l:k.'[P  <Plug>(fakeclip'.l:v.'-[P)'
+    execute 'silent! vmap '.modifier.' "'.l:k.'p  <Plug>(fakeclip'.l:v.'-p)'
+    execute 'silent! vmap '.modifier.' "'.l:k.'P  <Plug>(fakeclip'.l:v.'-P)'
+    execute 'silent! vmap '.modifier.' "'.l:k.'gp  <Plug>(fakeclip'.l:v.'-gp)'
+    execute 'silent! vmap '.modifier.' "'.l:k.'gP  <Plug>(fakeclip'.l:v.'-gP)'
+    execute 'silent! vmap '.modifier.' "'.l:k.']p  <Plug>(fakeclip'.l:v.'-]p)'
+    execute 'silent! vmap '.modifier.' "'.l:k.']P  <Plug>(fakeclip'.l:v.'-]P)'
+    execute 'silent! vmap '.modifier.' "'.l:k.'[p  <Plug>(fakeclip'.l:v.'-[p)'
+    execute 'silent! vmap '.modifier.' "'.l:k.'[P  <Plug>(fakeclip'.l:v.'-[P)'
 
-  execute 'silent! nmap '.modifier.' "&p  <Plug>(fakeclip-screen-p)'
-  execute 'silent! nmap '.modifier.' "&P  <Plug>(fakeclip-screen-P)'
-  execute 'silent! nmap '.modifier.' "&gp  <Plug>(fakeclip-screen-gp)'
-  execute 'silent! nmap '.modifier.' "&gP  <Plug>(fakeclip-screen-gP)'
-  execute 'silent! nmap '.modifier.' "&]p  <Plug>(fakeclip-screen-]p)'
-  execute 'silent! nmap '.modifier.' "&]P  <Plug>(fakeclip-screen-]P)'
-  execute 'silent! nmap '.modifier.' "&[p  <Plug>(fakeclip-screen-[p)'
-  execute 'silent! nmap '.modifier.' "&[P  <Plug>(fakeclip-screen-[P)'
-  execute 'silent! vmap '.modifier.' "&p  <Plug>(fakeclip-screen-p)'
-  execute 'silent! vmap '.modifier.' "&P  <Plug>(fakeclip-screen-P)'
-  execute 'silent! vmap '.modifier.' "&gp  <Plug>(fakeclip-screen-gp)'
-  execute 'silent! vmap '.modifier.' "&gP  <Plug>(fakeclip-screen-gP)'
-  execute 'silent! vmap '.modifier.' "&]p  <Plug>(fakeclip-screen-]p)'
-  execute 'silent! vmap '.modifier.' "&]P  <Plug>(fakeclip-screen-]P)'
-  execute 'silent! vmap '.modifier.' "&[p  <Plug>(fakeclip-screen-[p)'
-  execute 'silent! vmap '.modifier.' "&[P  <Plug>(fakeclip-screen-[P)'
+    execute 'silent! map! '.modifier.' <C-r>'.l:k.'  <Plug>(fakeclip'.l:v.'-insert)'
+    execute 'silent! map! '.modifier.' <C-r><C-r>'.l:k.'  <Plug>(fakeclip'.l:v.'-insert-r)'
+    execute 'silent! map! '.modifier.' <C-r><C-o>'.l:k.'  <Plug>(fakeclip'.l:v.'-insert-o)'
+    execute 'silent! imap '.modifier.' <C-r><C-p>'.l:k.'  <Plug>(fakeclip'.l:v.'-insert-p)'
 
-  execute 'silent! map! '.modifier.' <C-r>&  <Plug>(fakeclip-screen-insert)'
-  execute 'silent! map! '.modifier.' <C-r><C-r>&  <Plug>(fakeclip-screen-insert-r)'
-  execute 'silent! map! '.modifier.' <C-r><C-o>&  <Plug>(fakeclip-screen-insert-o)'
-  execute 'silent! imap '.modifier.' <C-r><C-p>&  <Plug>(fakeclip-screen-insert-p)'
-
-  execute 'silent! nmap '.modifier.' "&d  <Plug>(fakeclip-screen-d)'
-  execute 'silent! vmap '.modifier.' "&d  <Plug>(fakeclip-screen-d)'
-  execute 'silent! nmap '.modifier.' "&dd  <Plug>(fakeclip-screen-dd)'
-  execute 'silent! nmap '.modifier.' "&D  <Plug>(fakeclip-screen-D)'
-  execute 'silent! vmap '.modifier.' "&D  <Plug>(fakeclip-screen-D)'
+    execute 'silent! nmap '.modifier.' "'.l:k.'d  <Plug>(fakeclip'.l:v.'-d)'
+    execute 'silent! vmap '.modifier.' "'.l:k.'d  <Plug>(fakeclip'.l:v.'-d)'
+    execute 'silent! nmap '.modifier.' "'.l:k.'dd  <Plug>(fakeclip'.l:v.'-dd)'
+    execute 'silent! nmap '.modifier.' "'.l:k.'D  <Plug>(fakeclip'.l:v.'-D)'
+    execute 'silent! vmap '.modifier.' "'.l:k.'D  <Plug>(fakeclip'.l:v.'-D)'
+  endfor
 endfunction
 
 if !exists('g:fakeclip_no_default_key_mappings')

--- a/plugin/fakeclip.vim
+++ b/plugin/fakeclip.vim
@@ -26,6 +26,10 @@
 if exists('g:loaded_fakeclip')
   finish
 endif
+let g:loaded_fakeclip = 1
+
+let s:save_cpo = &cpo
+set cpo&vim
 
 
 
@@ -299,7 +303,7 @@ endif
 
 " Epilogue  "{{{1
 
-let g:loaded_fakeclip = 1
+let &cpo = s:save_cpo
 
 
 


### PR DESCRIPTION
Hi,

Sorry for sending you my admittedly disorganized branch.  I know this could look quite spammy now that mine has diverged from yours by quite a bit, but over the years I thought you'd stopped active maintenance so I kind of took matters into my own hands.  I've made fixes here and there and I'm just letting you know about it.  You may decide whether to merge them or pick out some commits from there.

To summarize, I've done the following things during the while..

* For X11 systems, recognize the distinction between Selection and Clipboard.  The former is made accessible with `*` and the latter `+` (congma/vim-fakeclip@dde26b6).
* Allow the user to override the read and write commands (congma/vim-fakeclip@d355b21).
* Perform some additional probing to detect the presence of the X11 app `xsel` and use it if it's the only one available (congma/vim-fakeclip@bb39965).
* Vim script convention compliance (congma/vim-fakeclip@c616a80).
* Misc fixes, such as (congma/vim-fakeclip@c37885c) which makes key-mapping generation a bit more simple (in my opinion), and (congma/vim-fakeclip@3bd6792) which follows Vim convention with tags in docs.