### PR TITLE
Fix pasting in WSL when CWD is not under "/mnt/c/"

### DIFF
--- a/autoload/fakeclip.vim
+++ b/autoload/fakeclip.vim
@@ -167,7 +167,8 @@ endfunction
 
 
 function! s:read_clipboard_wsl()
-  let text = system('powershell.exe -Command Get-Clipboard')
+  let text = system('cd $(dirname $(which powershell.exe)) &&
+                    \ powershell.exe -Command Get-Clipboard')
   let text = substitute(text, "\r", '', 'g')
   return text
 endfunction


### PR DESCRIPTION
Fix for issue #20.

The underlining issue is that when you try to run powershell.exe it tries to figure out the current working directory. If it can't, it will output an error message and set its working directory to something else (e.g. "C:\WINDOWS\System32"). So when working from a Linux path (e.g. "/home/eran/") it would fail and the error message would appear before the clipboard data.

The fix is simply to set the working directory, for the execution, to be the location of powershell.exe.