### PR TITLE
Gave priority to xclip over wsl

### DIFF
--- a/autoload/fakeclip.vim
+++ b/autoload/fakeclip.vim
@@ -25,18 +25,19 @@
 
 if has('macunix') || system('uname') =~? '^darwin'
   let s:PLATFORM = 'mac'
+elseif $DISPLAY != '' && executable('xclip')
+  let s:PLATFORM = 'x'
 elseif system('cat /proc/sys/kernel/osrelease') =~? 'Microsoft'
   let s:PLATFORM = 'wsl'
 elseif has('win32unix')
   let s:PLATFORM = 'cygwin'
-elseif $DISPLAY != '' && executable('xclip')
-  let s:PLATFORM = 'x'
 elseif executable('lemonade')
   let s:PLATFORM = 'lemonade'
 else
   let s:PLATFORM = 'unknown'
 endif
 
+let g:fakeclip_platform=s:PLATFORM
 
 if executable('tmux') && $TMUX != ''
   let g:fakeclip_terminal_multiplexer_type = 'tmux'


### PR DESCRIPTION
I got latencie with the wsl mode. It seems running PowerShell takes about 1 second to paste a text. 

I installed xclip and installed Xming, but fakeclip was still using the wsl mode. I eventually swapped the conditional to give priority to xclip. 

Also I added a global variable to read the fakeclip platform. 