### PR TITLE
Fix more issues with WSL

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .vim-flavor
 Gemfile.lock
 VimFlavor.lock
+doc/tags

--- a/autoload/fakeclip.vim
+++ b/autoload/fakeclip.vim
@@ -170,6 +170,7 @@ function! s:read_clipboard_wsl()
   let text = system('cd $(dirname $(which powershell.exe)) &&
                     \ powershell.exe -noprofile -Command Get-Clipboard')
   let text = substitute(text, "\r", '', 'g')
+  let text = substitute(text, '\n$', '', '')
   return text
 endfunction
 

--- a/autoload/fakeclip.vim
+++ b/autoload/fakeclip.vim
@@ -168,7 +168,7 @@ endfunction
 
 function! s:read_clipboard_wsl()
   let text = system('cd $(dirname $(which powershell.exe)) &&
-                    \ powershell.exe -Command Get-Clipboard')
+                    \ powershell.exe -noprofile -Command Get-Clipboard')
   let text = substitute(text, "\r", '', 'g')
   return text
 endfunction

--- a/autoload/fakeclip.vim
+++ b/autoload/fakeclip.vim
@@ -167,8 +167,7 @@ endfunction
 
 
 function! s:read_clipboard_wsl()
-  let text = system('cd $(dirname $(which powershell.exe)) &&
-                    \ powershell.exe -noprofile -Command Get-Clipboard')
+  let text = system('powershell.exe -NoProfile -Command Get-Clipboard 2>/dev/null')
   let text = substitute(text, "\r", '', 'g')
   let text = substitute(text, '\n$', '', '')
   return text


### PR DESCRIPTION
To improve the performance of Powershell, we can disable the loading of the profile.

On my machine:

```console
$ time powershell.exe -command get-clipboard > /dev/null

real    0m1.693s
user    0m0.016s
sys     0m0.016s

$ time powershell.exe -noprofile -command get-clipboard > /dev/null

real    0m0.410s
user    0m0.000s
sys     0m0.031s
```

Also changes the `.gitignore`, since I had some issues with it picking up `doc/tags`. I'm not sure this is correct though, let me know if I should drop it.

The other issue this fixes is the phantom newlines that are added by powershell when using `get-clipboard`.

```console
$ printf '123' | clip.exe; powershell.exe get-clipboard | xxd
00000000: 3132 330d 0a                             123..
$ printf '123\r\n' | clip.exe; powershell.exe get-clipboard | xxd
00000000: 3132 330d 0a0d 0a                        123....
```