### PR TITLE
Add support for wl-clipboard for Wayland

### DIFF
--- a/autoload/fakeclip.vim
+++ b/autoload/fakeclip.vim
@@ -29,6 +29,8 @@ elseif system('cat /proc/sys/kernel/osrelease') =~? 'Microsoft'
   let s:PLATFORM = 'wsl'
 elseif has('win32unix')
   let s:PLATFORM = 'cygwin'
+elseif $WAYLAND_DISPLAY != '' && executable('wl-copy')
+  let s:PLATFORM = 'wayland'
 elseif $DISPLAY != '' && executable('xclip')
   let s:PLATFORM = 'x'
 elseif executable('lemonade')
@@ -183,6 +185,15 @@ function! s:read_clipboard_cygwin()
 endfunction
 
 
+function! s:read_clipboard_wayland()
+  let text = system('wl-paste --no-newline')
+  " Note: GTK+ adds \r to clipboard content, usually undesirable in Vim
+  " See https://gitlab.gnome.org/GNOME/gtk/issues/2307
+  let text = substitute(text, "\r", '', 'g')
+  return text
+endfunction
+
+
 function! s:read_clipboard_x()
   return system('xclip -o')
 endfunction
@@ -263,6 +274,12 @@ endfunction
 
 function! s:write_clipboard_cygwin(text)
   call writefile(split(a:text, "\x0A", 1), '/dev/clipboard', 'b')
+  return
+endfunction
+
+
+function! s:write_clipboard_wayland(text)
+  call system('wl-copy', a:text)
   return
 endfunction
 


### PR DESCRIPTION
Since Vim does not support [Wayland] natively (see vim/vim#5157) and at least one popular Wayland compositor (Sway) doesn't synchronize the XWayland clipboard without a focused window (see swaywm/sway#5352), a plugin like fakeclip could be a very useful way to interact with the Wayland clipboard.

This PR adds support for the Wayland clipboard using `wl-copy` and `wl-paste` from [wl-clipboard], enabled based on the presence of `$WAYLAND_DISPLAY`.

Thanks for considering,
Kevin

[Wayland]: https://wayland.freedesktop.org/
[wl-clipboard]: https://github.com/bugaevc/wl-clipboard